### PR TITLE
lifecycle:2.6.0-alpha04：[FullLifecycleObserver] deleted

### DIFF
--- a/binding/src/main/java/androidx/lifecycle/BindingLifecycleObserver.kt
+++ b/binding/src/main/java/androidx/lifecycle/BindingLifecycleObserver.kt
@@ -8,7 +8,7 @@ package androidx.lifecycle
  * </pre>
  */
 
-open class BindingLifecycleObserver : FullLifecycleObserver {
+open class BindingLifecycleObserver : DefaultLifecycleObserver {
 
     override fun onCreate(owner: LifecycleOwner) {
     }


### PR DESCRIPTION
"`DefaultLifecycleObserver` now
extends the public `LifecycleObserver` directly
and `FullLifecycleObserver` has been deleted,
transferring all of its functionality to
`DefaultLifecycleObserver`."
link:https://android.googlesource.com/platform/frameworks/support/+/4fffb14cfdcfeaa713639466de257639e80664db